### PR TITLE
Fix event handling in web-bluetooth api

### DIFF
--- a/dist/api.web-bluetooth.js
+++ b/dist/api.web-bluetooth.js
@@ -72,26 +72,25 @@
         }
     }
 
-    var events = {};
     function createListenerFn(eventTypes) {
         return function(type, callback, capture) {
             if (eventTypes.indexOf(type) < 0) return; //error
-            if (!events[this]) events[this] = {};
-            if (!events[this][type]) events[this][type] = [];
-            events[this][type].push(callback);
+            if (!this.__events) this.__events = {};
+            if (!this.__events[type]) this.__events[type] = [];
+            this.__events[type].push(callback);
         };
     }
     function removeEventListener(type, callback, capture) {
-        if (!events[this] || !events[this][type]) return; //error
-        var i = events[this][type].indexOf(callback);
-        if (i >= 0) events[this][type].splice(i, 1);
-        if (events[this][type].length === 0) delete events[this][type];
-        if (Object.keys(events[this]).length === 0) delete events[this];
+        if (!this.__events || !this.__events[type]) return; //error
+        var i = this.__events[type].indexOf(callback);
+        if (i >= 0) this.__events[type].splice(i, 1);
+        if (this.__events[type].length === 0) delete this.__events[type];
+        if (Object.keys(this.__events).length === 0) delete this.__events;
     }
     function dispatchEvent(event) {
-        if (!events[this] || !events[this][event.type]) return; //error
+        if (!this.__events || !this.__events[event.type]) return; //error
         event.target = this;
-        events[this][event.type].forEach(function(callback) {
+        this.__events[event.type].forEach(function(callback) {
             if (typeof callback === "function") callback(event);
         });
     }


### PR DESCRIPTION
Currently, all events are stored in a global objects called `events`, indexed by the target Object. This causes a bug where all event listeners are shared between all objects. The reason is that JavaScript only support string indices for objects, and therefore, `events[this]` actually becomes `events[this.toString()]`, and the `toString()` methods of all objects return '[object Object]'. 

So with the current implementation, all the event listeners are always stored inside `events['[object Object]']`, regardless of the actual object. The proposed fix simply stores the event listeners inside the object itself, in a property called `__events`. Another option would be to use Symbol or WeakMap, if we target ES6 only.