### PR TITLE
Check if deviceInfo.name is null

### DIFF
--- a/dist/api.web-bluetooth.js
+++ b/dist/api.web-bluetooth.js
@@ -99,7 +99,7 @@
 
             // NamePrefix
             if (filter.namePrefix) {
-                if (filter.namePrefix.length > deviceInfo.name.length) return;
+                if (!deviceInfo.name || filter.namePrefix.length > deviceInfo.name.length) return;
                 if (filter.namePrefix !== deviceInfo.name.substr(0, filter.namePrefix.length)) return;
             }
 


### PR DESCRIPTION
Prevent TypeError: null is not an object (evaluating 'b.name.length')